### PR TITLE
Remove 'certs' target from 'all' scope

### DIFF
--- a/config/Makefile
+++ b/config/Makefile
@@ -2,7 +2,7 @@ VPATH=/dev .phonytarget
 
 enough: kernel-modules loop0 loop1
 
-all: docker packages kernel-modules certs loop0 loop1
+all: docker packages kernel-modules loop0 loop1
 
 post-boot: kernel-modules loop0 loop1
 


### PR DESCRIPTION
certs target was removed in
3d91f95849a07ff04dfdda3f3f3eab2b4599b36f commit.